### PR TITLE
#114 Host on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
-[build]
+[build.environment]
   HUGO_VERSION = "0.70.0"


### PR DESCRIPTION
moves hosting of website from Manitu to netlify.

This way, we get 

- faster build times
- CI/CD instead of manually uploading to FTP
- branch previews