### PR TITLE
Deploy to ftp using Github actions

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,44 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Set a branch to deploy
+      - gh-action-deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.70.0'
+          # extended: true
+
+
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/hugo_cache
+          key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-hugomod-
+      - name: Build
+        run: hugo --minify
+
+      - name: 📂 Sync files
+        uses: SamKirkland/FTP-Deploy-Action@4.2.0
+        with:
+          server: ${{ secrets.ftp_server }}
+          username: ${{ secrets.ftp_username }}
+          password: ${{ secrets.ftp_password }}
+          protocol: ftps 
+          local-dir: ./public/
+          server-dir: /web/

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main  # Set a branch to deploy
-      - gh-action-deploy
     paths:
       - "archetypes/**"
       - "content/**"

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main  # Set a branch to deploy
       - gh-action-deploy
+    paths:
+      - "archetypes/**"
+      - "content/**"
+      - "data/**"
+      - "i18n/**"
+      - "layouts/**"
+      - "resources/**"
+      - "static/**"
+      - ".github/**"
+      - "config.toml"
 
 jobs:
   deploy:
@@ -30,6 +40,7 @@ jobs:
           key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-hugomod-
+
       - name: Build
         run: hugo --minify
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Netlify Status](https://api.netlify.com/api/v1/badges/2c8e5dc8-1df6-4b21-bfdb-77af3b1d525a/deploy-status)](https://app.netlify.com/sites/jolly-boyd-ddf9b1/deploys) [![buddy pipeline](https://app.buddy.works/correlaid/hugo-website/pipelines/pipeline/278548/badge.svg?token=6a0bb1686911e5f7ac4a49c400da307388ecd3dfa40e8f56bd2ed996ace28902 "buddy pipeline")](https://app.buddy.works/correlaid/hugo-website/pipelines/pipeline/278548) [![buddy pipeline](https://app.buddy.works/correlaid/hugo-website/pipelines/pipeline/277663/badge.svg?token=6a0bb1686911e5f7ac4a49c400da307388ecd3dfa40e8f56bd2ed996ace28902 "buddy pipeline")](https://app.buddy.works/correlaid/hugo-website/pipelines/pipeline/277663)
-
+[![Netlify Status](https://api.netlify.com/api/v1/badges/2c8e5dc8-1df6-4b21-bfdb-77af3b1d525a/deploy-status)](https://app.netlify.com/sites/jolly-boyd-ddf9b1/deploys) 
+[<img alt="Deployed with FTP Deploy Action" src="https://img.shields.io/badge/Deployed With-FTP DEPLOY ACTION-%3CCOLOR%3E?style=for-the-badge&color=0077b6">](https://github.com/SamKirkland/FTP-Deploy-Action)
 # CorrelAid Hugo Website
 0. Licensing information
 1. [Installation](#1-installation)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/2c8e5dc8-1df6-4b21-bfdb-77af3b1d525a/deploy-status)](https://app.netlify.com/sites/jolly-boyd-ddf9b1/deploys) 
 [<img alt="Deployed with FTP Deploy Action" src="https://img.shields.io/badge/Deployed With-FTP DEPLOY ACTION-%3CCOLOR%3E?style=for-the-badge&color=0077b6">](https://github.com/SamKirkland/FTP-Deploy-Action)
+
 # CorrelAid Hugo Website
 0. Licensing information
 1. [Installation](#1-installation)
@@ -64,7 +65,7 @@ Hugo provides a development server that enables _hot-reload_. The folder is watc
 
 1. Commit your changes to GitHub. If you're not an admin, you cannot push to the `main` branch, so please create a branch for your changes and then open a pull request. 
 2. Pull requests to the `main` branched are built into a _deploy preview_ by Netlify. You will see this in the PR status checks. If you click on "Details" for the last status check (it should say something like "Deploy preview ready!"), you'll be taken to the deploy preview.
-3. After someone has reviewed your changes and approved them, they'll be merged to `main` and automatically deployed to our FTP server by [buddy.works](buddy.works). You can check the status of this deployment by looking at the badge in the README.
+3. After someone has reviewed your changes and approved them, they'll be merged to `main` and automatically deployed to our FTP server by GitHub Actions. You can check the status of this deployment by looking at the "Actions" tab of the GitHub Repository.
 
 ## 4. Add content
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Netlify Status](https://api.netlify.com/api/v1/badges/2c8e5dc8-1df6-4b21-bfdb-77af3b1d525a/deploy-status)](https://app.netlify.com/sites/jolly-boyd-ddf9b1/deploys) 
 [<img alt="Deployed with FTP Deploy Action" src="https://img.shields.io/badge/Deployed With-FTP DEPLOY ACTION-%3CCOLOR%3E?style=for-the-badge&color=0077b6">](https://github.com/SamKirkland/FTP-Deploy-Action)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/2c8e5dc8-1df6-4b21-bfdb-77af3b1d525a/deploy-status)](https://app.netlify.com/sites/jolly-boyd-ddf9b1/deploys) 
 
 # CorrelAid Hugo Website
 0. Licensing information
@@ -65,7 +65,7 @@ Hugo provides a development server that enables _hot-reload_. The folder is watc
 
 1. Commit your changes to GitHub. If you're not an admin, you cannot push to the `main` branch, so please create a branch for your changes and then open a pull request. 
 2. Pull requests to the `main` branched are built into a _deploy preview_ by Netlify. You will see this in the PR status checks. If you click on "Details" for the last status check (it should say something like "Deploy preview ready!"), you'll be taken to the deploy preview.
-3. After someone has reviewed your changes and approved them, they'll be merged to `main` and automatically deployed to our FTP server by GitHub Actions. You can check the status of this deployment by looking at the "Actions" tab of the GitHub Repository.
+3. After someone has reviewed your changes and approved them, they'll be merged to `main` and automatically deployed to our FTP server by GitHub Actions. You can check the status of this deployment by looking at the "Actions" tab of the GitHub Repository. This will only happend if you have modified files that are actually relevant to the website, i.e. updating the README will not trigger a build.
 
 ## 4. Add content
 


### PR DESCRIPTION
switches from [buddy](https://buddy.works) to GitHub actions. this makes deployments easier to track and reduces the number of services we use. 